### PR TITLE
Replace settings l10n for first-run wizard button

### DIFF
--- a/settings/l10n/zh_TW.js
+++ b/settings/l10n/zh_TW.js
@@ -1,0 +1,6 @@
+OC.L10N.register(
+    "settings",
+    {
+    "Show First Run Wizard again" : "再次顯示服務使用規範"
+},
+"nplurals=1; plural=0;");

--- a/settings/l10n/zh_TW.json
+++ b/settings/l10n/zh_TW.json
@@ -1,0 +1,4 @@
+{ "translations": {
+    "Show First Run Wizard again" : "再次顯示服務使用規範"
+},"pluralForm" :"nplurals=1; plural=0;"
+}


### PR DESCRIPTION
The first-run wizard content is replaced to terms of service,
for the same purpose, the button should also replace so.
The original l10n of zh_TW in settings is amended.
